### PR TITLE
Replace solidus_globalize function call and redirect updateState

### DIFF
--- a/solidus_bootstrap/frontend/app/assets/javascripts/spree/frontend/checkout/address.js.coffee
+++ b/solidus_bootstrap/frontend/app/assets/javascripts/spree/frontend/checkout/address.js.coffee
@@ -77,6 +77,6 @@ Spree.ready ($) ->
       else
         ($ '#shipping .inner').show()
         ($ '#shipping .inner input, #shipping .inner select').prop 'disabled', false
-        Spree.updateState('s')
+        updateState('s')
 
     update_shipping_form_state order_use_billing

--- a/solidus_bootstrap/frontend/app/views/spree/shared/_locale_selector.html.erb
+++ b/solidus_bootstrap/frontend/app/views/spree/shared/_locale_selector.html.erb
@@ -1,4 +1,4 @@
-<% if supported_locales_options.size > 1 %>
+<% if available_locales_options.size > 1 %>
   <li id="locale-selector" class="visible-md-inline visible-lg-inline">
     <a href="#" role="button" class="dropdown-toggle" data-toggle="dropdown" id="dropdownMenuLanguage">
       <%#<span class="visible-xs-inline visible-sm-inline"><%#= fa_icon("language", text: Spree.t(:'i18n.language')) ></span><span class="inline hidden-md">&nbsp;%><%= I18n.locale.to_s.upcase %> <%# </span>


### PR DESCRIPTION
The function call you introduced in November is part of *solidus_globalize* ([see here](https://github.com/solidusio-contrib/solidus_globalize/blob/master/app/helpers/solidus_globalize/locale_helper.rb#L19) and not of solidus i18n.