### PR TITLE
Improve install generator

### DIFF
--- a/solidus_bootstrap/frontend/lib/generators/solidus_frontend_bootstrap/install/install_generator.rb
+++ b/solidus_bootstrap/frontend/lib/generators/solidus_frontend_bootstrap/install/install_generator.rb
@@ -5,11 +5,25 @@ module SolidusFrontendBootstrap
       
       source_root File.expand_path("../templates", __FILE__)
 
-      def copy_stylesheets
+      def add_stylesheets
         copy_file 'stylesheets/bootstrap_frontend.css.scss',
                   'app/assets/stylesheets/spree/frontend/bootstrap_frontend.css.scss'
-        copy_file 'stylesheets/all.css',
-                  'vendor/assets/stylesheets/spree/frontend/all.css'
+
+        string = "*= require spree/frontend/bootstrap_frontend"
+        
+        f = 'vendor/assets/stylesheets/spree/frontend/all.css'
+        gsub_regex = /^\*=(\ *)require spree\/frontend(?!\/)(.*)/
+        inject_regex = /^\*=(\ *)require_self/
+        
+        if File.readlines(f).grep(gsub_regex).any?
+          gsub_file f, gsub_regex do |match|
+            "#{match.sub('*=','*')}\n#{string}"
+          end
+        elsif File.readlines(f).grep(inject_regex).any?
+          inject_into_file f, "#{string}\n", before: inject_regex, verbose: true
+        else
+          copy_file 'stylesheets/all.css', 'vendor/assets/stylesheets/spree/frontend/all.css'
+        end
       end
     end
   end

--- a/solidus_bootstrap/frontend/lib/generators/solidus_frontend_bootstrap/install/templates/stylesheets/all.css
+++ b/solidus_bootstrap/frontend/lib/generators/solidus_frontend_bootstrap/install/templates/stylesheets/all.css
@@ -1,6 +1,7 @@
 /*
 * This is a manifest file that includes stylesheets for spree_frontend
 * Spree_bootstrap_frontend overrides all spree’s default css and resets here in favour of bootstrap
+*
 *= require spree/frontend/bootstrap_frontend
 *= require_self
 *= require_tree .


### PR DESCRIPTION
Improve install generator to attempt to edit the text in `endor/assets/stylesheets/spree/frontend/all.css` before using the rudimentary `copy_file`